### PR TITLE
Fix: Corrigi a lógica de exclusão de diretórios de backup

### DIFF
--- a/D:/w/analise-dados/tests/data/strip_whitespace_test/fad-bkp-treatment-20250801195944/whitespace_test.csv
+++ b/D:/w/analise-dados/tests/data/strip_whitespace_test/fad-bkp-treatment-20250801195944/whitespace_test.csv
@@ -1,0 +1,4 @@
+ "Nome"  ;"  Idade ";"  Cidade  "
+ "  João  " ;" 25 ";"  São Paulo  "
+" Maria ";"30";"Rio de Janeiro"
+"  José";" 35 ";"  Belo Horizonte  "

--- a/D:/w/analise-dados/tests/data/strip_whitespace_test/fad-bkp-treatment-20250801200021/whitespace_test.csv
+++ b/D:/w/analise-dados/tests/data/strip_whitespace_test/fad-bkp-treatment-20250801200021/whitespace_test.csv
@@ -1,0 +1,4 @@
+ "Nome"  ;"  Idade ";"  Cidade  "
+ "  João  " ;" 25 ";"  São Paulo  "
+" Maria ";"30";"Rio de Janeiro"
+"  José";" 35 ";"  Belo Horizonte  "

--- a/D:/w/analise-dados/tests/data/strip_whitespace_test/fad-bkp-treatment-20250801200047/whitespace_test.csv
+++ b/D:/w/analise-dados/tests/data/strip_whitespace_test/fad-bkp-treatment-20250801200047/whitespace_test.csv
@@ -1,0 +1,4 @@
+ "Nome"  ;"  Idade ";"  Cidade  "
+ "  João  " ;" 25 ";"  São Paulo  "
+" Maria ";"30";"Rio de Janeiro"
+"  José";" 35 ";"  Belo Horizonte  "

--- a/D:/w/analise-dados/tests/data/strip_whitespace_test/fad-bkp-treatment-20250801200116/whitespace_test.csv
+++ b/D:/w/analise-dados/tests/data/strip_whitespace_test/fad-bkp-treatment-20250801200116/whitespace_test.csv
@@ -1,0 +1,4 @@
+ "Nome"  ;"  Idade ";"  Cidade  "
+ "  João  " ;" 25 ";"  São Paulo  "
+" Maria ";"30";"Rio de Janeiro"
+"  José";" 35 ";"  Belo Horizonte  "

--- a/D:/w/analise-dados/tests/data/strip_whitespace_test/fad-bkp-treatment-20250801200141/whitespace_test.csv
+++ b/D:/w/analise-dados/tests/data/strip_whitespace_test/fad-bkp-treatment-20250801200141/whitespace_test.csv
@@ -1,0 +1,4 @@
+ "Nome"  ;"  Idade ";"  Cidade  "
+ "  João  " ;" 25 ";"  São Paulo  "
+" Maria ";"30";"Rio de Janeiro"
+"  José";" 35 ";"  Belo Horizonte  "

--- a/D:/w/analise-dados/tests/data/strip_whitespace_test/fad-bkp-treatment-20250801200237/whitespace_test.csv
+++ b/D:/w/analise-dados/tests/data/strip_whitespace_test/fad-bkp-treatment-20250801200237/whitespace_test.csv
@@ -1,0 +1,4 @@
+ "Nome"  ;"  Idade ";"  Cidade  "
+ "  João  " ;" 25 ";"  São Paulo  "
+" Maria ";"30";"Rio de Janeiro"
+"  José";" 35 ";"  Belo Horizonte  "

--- a/D:/w/analise-dados/tests/data/strip_whitespace_test/fad-metadados/treatment_report.json
+++ b/D:/w/analise-dados/tests/data/strip_whitespace_test/fad-metadados/treatment_report.json
@@ -1,0 +1,14 @@
+{
+    "summary": {
+        "total_files": 1,
+        "processed_successfully": 1,
+        "failed": 0
+    },
+    "details": [
+        {
+            "file_name": "whitespace_test.csv",
+            "status": "Success",
+            "changes_made": true
+        }
+    ]
+}

--- a/D:/w/analise-dados/tests/data/strip_whitespace_test/whitespace_test.csv
+++ b/D:/w/analise-dados/tests/data/strip_whitespace_test/whitespace_test.csv
@@ -1,0 +1,4 @@
+﻿" ""Nome""  ";  Idade ;  Cidade
+"""  João  """;25;São Paulo
+Maria;30;Rio de Janeiro
+José;35;Belo Horizonte

--- a/src/utils.py
+++ b/src/utils.py
@@ -47,9 +47,13 @@ def find_files(root_path: str, extensions: list[str], recursive: bool = True, ex
     normalized_extensions = [ext.lower().lstrip('.') for ext in extensions]
     exclude_patterns = exclude_patterns or []
 
-    # Se exclude_dirs não for fornecido, usa a lista padrão.
-    if exclude_dirs is None:
-        exclude_dirs = ['fad-metadados', 'fad-config', 'fad-bkp*']
+    # Define a lista de exclusão padrão e a combina com quaisquer exclusões extras.
+    default_exclude_dirs = ['fad-metadados', 'fad-config', 'fad-bkp*']
+    if exclude_dirs:
+        # Usa um set para evitar duplicatas e combina as listas
+        final_exclude_dirs = list(set(default_exclude_dirs) | set(exclude_dirs))
+    else:
+        final_exclude_dirs = default_exclude_dirs
 
     if not os.path.isdir(root_path):
         print(f"Erro: O diretório raiz '{root_path}' não existe ou não é um diretório.", file=sys.stderr)
@@ -61,7 +65,7 @@ def find_files(root_path: str, extensions: list[str], recursive: bool = True, ex
             original_dirnames = list(dirnames)
             dirnames[:] = []
             for d in original_dirnames:
-                if not any(fnmatch.fnmatch(d, pattern) for pattern in exclude_dirs):
+                if not any(fnmatch.fnmatch(d, pattern) for pattern in final_exclude_dirs):
                     dirnames.append(d)
 
             for filename in filenames:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -94,36 +94,45 @@ def test_find_files_with_default_excluded_dirs(tmp_path):
     assert len(found_files) == 1
     assert str(f_valid) in found_files
 
-def test_find_files_with_custom_excluded_dirs(tmp_path):
-    """Testa se a passagem de uma lista de exclusão personalizada sobrepõe a padrão."""
+def test_find_files_combines_excluded_dirs(tmp_path):
+    """
+    Testa se a função find_files combina a lista de exclusão padrão
+    com uma lista personalizada, em vez de substituí-la.
+    """
     # Arrange
-    # Diretório que seria ignorado por padrão, mas não deve ser com a lista personalizada
+    # Diretórios que devem ser ignorados pela regra padrão
     (tmp_path / "fad-metadados").mkdir()
-    f_meta = tmp_path / "fad-metadados" / "meta.csv"
-    f_meta.write_text("metadata")
+    (tmp_path / "fad-metadados" / "meta.csv").write_text("metadata")
+    (tmp_path / "fad-bkp-old-123").mkdir()
+    (tmp_path / "fad-bkp-old-123" / "backup1.csv").write_text("backup")
 
-    # Diretório que deve ser ignorado pela lista personalizada
+    # Diretório que deve ser ignorado pela regra personalizada
     (tmp_path / "custom-ignore").mkdir()
     (tmp_path / "custom-ignore" / "ignored.csv").write_text("ignored")
 
-    f_valid = tmp_path / "data.csv"
-    f_valid.write_text("content")
+    # Diretório de backup da execução atual, também a ser ignorado
+    (tmp_path / "fad-bkp-new-456").mkdir()
+    (tmp_path / "fad-bkp-new-456" / "backup2.csv").write_text("backup")
+
+    # Arquivo válido que deve ser encontrado
+    f_valid = tmp_path / "data"
+    f_valid.mkdir()
+    valid_file = f_valid / "valid_data.csv"
+    valid_file.write_text("valid_content")
 
     # Act
-    # Passa uma lista de exclusão vazia, esperando que NADA seja ignorado
-    found_files_custom_empty = utils.find_files(str(tmp_path), ["csv"], exclude_dirs=[])
-
-    # Passa uma lista de exclusão personalizada
-    found_files_custom = utils.find_files(str(tmp_path), ["csv"], exclude_dirs=['custom-ignore'])
+    # Chama a função passando a pasta de backup da execução atual e uma pasta customizada
+    # A função deve ignorar as pastas padrão (fad-metadados, fad-bkp-*) E as personalizadas
+    found_files = utils.find_files(
+        str(tmp_path),
+        ["csv"],
+        exclude_dirs=['custom-ignore', 'fad-bkp-new-456']
+    )
 
     # Assert
-    assert len(found_files_custom_empty) == 3
-    assert str(f_meta) in found_files_custom_empty
-    assert str(f_valid) in found_files_custom_empty
-
-    assert len(found_files_custom) == 2
-    assert str(f_meta) in found_files_custom
-    assert str(f_valid) in found_files_custom
+    # Apenas o arquivo 'valid_data.csv' deve ser encontrado
+    assert len(found_files) == 1
+    assert str(valid_file) in found_files
 
 def test_read_csv_robust(tmp_path):
     """Testa a leitura de um arquivo CSV válido."""


### PR DESCRIPTION
Alterei a função `find_files` para combinar a lista de exclusão padrão com a lista que você forneceu, em vez de substituí-la. Isso garante que os diretórios de backup (`fad-bkp-*`) sejam sempre ignorados, mesmo quando você especifica exclusões personalizadas.

Também adicionei um teste de integração para validar o novo comportamento.